### PR TITLE
missing regex bracket in support.function.arithmetic.mips

### DIFF
--- a/syntaxes/mips.tmLanguage.json
+++ b/syntaxes/mips.tmLanguage.json
@@ -79,7 +79,7 @@
           "match": "\\b(if|while|for|return)\\b"
         },
         {
-          "match": "\\b(abs|add[i]?[u]?|and[i]?|div[u]?|mul(o|t)?[u]?|or[i]?|not|nor|sub[i]?[u]?|xor[i]?|sll[v]?|sr[al][v]?|se(b|h)|s(eq|ne)|s(gt|lt|ge|le)[u]?\\b",
+          "match": "\\b(abs|add[i]?[u]?|and[i]?|div[u]?|mul(o|t)?[u]?|or[i]?|not|nor|sub[i]?[u]?|xor[i]?|sll[v]?|sr[al][v]?|se(b|h)|s(eq|ne)|s(gt|lt|ge|le)[u]?)\\b",
           "name": "support.function.arithmetic.mips"
         },
         {


### PR DESCRIPTION
Due to a missing bracket in the regex support.function.arithmetic.mips the syntax highlighting isn't working at all